### PR TITLE
update RoPE/cuRoPE

### DIFF
--- a/models/curope/kernels.cu
+++ b/models/curope/kernels.cu
@@ -98,7 +98,7 @@ void rope_2d_cuda( torch::Tensor tokens, const torch::Tensor pos, const float ba
     const int N_BLOCKS = B * N; // each block takes care of H*D values
     const int SHARED_MEM = sizeof(float) * (D + D/4);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, tokens.scalar_type(), "rope_2d_cuda", ([&] {
         rope_2d_cuda_kernel<scalar_t> <<<N_BLOCKS, THREADS_PER_BLOCK, SHARED_MEM>>> (
             //tokens.data_ptr<scalar_t>(), 
             tokens.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),

--- a/models/pos_embed.py
+++ b/models/pos_embed.py
@@ -117,7 +117,7 @@ except ImportError:
 
         def get_cos_sin(self, D, seq_len, device, dtype):
             if (D,seq_len,device,dtype) not in self.cache:
-                inv_freq = 1.0 / (self.base ** (torch.arange(0, D, 2).float().to(device) / D))
+                inv_freq = self.F0 / (self.base ** (torch.arange(0, D, 2).float().to(device) / D))
                 t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
                 freqs = torch.einsum("i,j->ij", t, inv_freq).to(dtype)
                 freqs = torch.cat((freqs, freqs), dim=-1)


### PR DESCRIPTION
address #43, #41 and fixes a bug on the pytorch implementation RoPE2D -> F0 was not used